### PR TITLE
Eliminate usage of "deprecated" deque.New

### DIFF
--- a/minmax/max.go
+++ b/minmax/max.go
@@ -30,7 +30,7 @@ func NewMax(window int) (*Max, error) {
 
 	return &Max{
 		queue:  queue.NewRingBuffer(uint64(window)),
-		deque:  deque.New[float64](),
+		deque:  new(deque.Deque[float64]),
 		max:    math.Inf(-1),
 		window: window,
 	}, nil
@@ -41,7 +41,7 @@ func NewMax(window int) (*Max, error) {
 func NewGlobalMax() *Max {
 	return &Max{
 		queue:  queue.NewRingBuffer(uint64(0)),
-		deque:  deque.New[float64](),
+		deque:  new(deque.Deque[float64]),
 		max:    math.Inf(-1),
 		window: 0,
 	}
@@ -115,5 +115,5 @@ func (m *Max) Clear() {
 	m.max = math.Inf(-1)
 	m.queue.Dispose()
 	m.queue = queue.NewRingBuffer(uint64(m.window))
-	m.deque = deque.New[float64]()
+	m.deque = new(deque.Deque[float64])
 }

--- a/minmax/min.go
+++ b/minmax/min.go
@@ -30,7 +30,7 @@ func NewMin(window int) (*Min, error) {
 
 	return &Min{
 		queue:  queue.NewRingBuffer(uint64(window)),
-		deque:  deque.New[float64](),
+		deque:  new(deque.Deque[float64]),
 		min:    math.Inf(1),
 		window: window,
 	}, nil
@@ -41,7 +41,7 @@ func NewMin(window int) (*Min, error) {
 func NewGlobalMin() *Min {
 	return &Min{
 		queue:  queue.NewRingBuffer(uint64(0)),
-		deque:  deque.New[float64](),
+		deque:  new(deque.Deque[float64]),
 		min:    math.Inf(1),
 		window: 0,
 	}
@@ -115,5 +115,5 @@ func (m *Min) Clear() {
 	m.min = math.Inf(1)
 	m.queue.Dispose()
 	m.queue = queue.NewRingBuffer(uint64(m.window))
-	m.deque = deque.New[float64]()
+	m.deque = new(deque.Deque[float64])
 }


### PR DESCRIPTION
The `New` constructor was removed in 'gammazero/deque' v1.0.0, so packages that depend on `stream`, but also depend on a newer version of `deque` won't build.

I've avoided actually bumping the dependencies of this package to deque v1.0.0 though, so that that 'stream' continues to work older versions of Go (deque v1.0.0 also bumps the minimum Go version to 1.22), in case that's important to you.

Fixes #4